### PR TITLE
Fix more errors & make highlighting.ts a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # AI CODE
 
-This is placeholder, and furthermore, this is early in development.
+This is placeholder, and furthermore, this is early in development. If you want to help, talk to me, and check out CONTRIBUTING.md

--- a/lib/highlight/highlight.ts
+++ b/lib/highlight/highlight.ts
@@ -1,12 +1,12 @@
 import {OnigRegExp} from "onigurumajs"
-
-const ref : {[key : string] : string[]} = await Bun.file("highlight/ref.json").json();
-async function getGrammar(extension : string) {
-    for (let i in ref) {
+const path = "lib/highlight"
+export async function getGrammar(extension : string) {
+	const ref : {[key : string] : string[]} = await Bun.file(`${path}/ref.json`).json();
+	for (let i in ref) {
         //console.log(ref[i], i)
         if (ref[i].includes(extension)) {
             //console.log(`code/${i}.json`)
-            return await Bun.file(`lib/highlight/code/${i}.json`).json();
+            return await Bun.file(`${path}/code/${i}.json`).json();
         }
     }
 }
@@ -21,7 +21,7 @@ type pattern =  {
 	endCaptures: {[key: string]: {name : string}},
 	include?: `#${string}` | null
 }
-function highlightSyntax(json:{patterns:pattern[],repository:{[key : string]: pattern}},text:string,theme?:{[type:string] : `#${{length: 6} & string}`}){
+export function highlightSyntax(json:{patterns:pattern[],repository:{[key : string]: pattern}},text:string,theme?:{[type:string] : `#${{length: 6} & string}`}){
     type highlight = [number,number, {
         types : string[],
 		includes: string[],
@@ -140,4 +140,3 @@ function highlightSyntax(json:{patterns:pattern[],repository:{[key : string]: pa
     return highlighted
 }
 
-console.log(highlightSyntax(await getGrammar('ts'),await Bun.file("lib/highlight/highlight.ts").text()).map(a=>JSON.stringify(a)).join('\n'))


### PR DESCRIPTION
1) I slightly changed the wording of README.md, to allow more volunteers.
2) I exported the 2 functions in highlight.ts to import.
3) I refactored highlight.ts to make sure that the path to the files is correct

HOW TO TEST:
```js
bun repl
require("./lib/highlight/highlight.ts").getGrammar("ts") // Can also use import statement

```